### PR TITLE
Play nice with Bower components

### DIFF
--- a/tasks/build.js
+++ b/tasks/build.js
@@ -28,6 +28,7 @@ var paths = {
     jsCode: [
         'app/**/*.js',
         '!app/node_modules/**',
+        '!app/bower_components/**',
         '!app/vendor/**'
     ]
 }


### PR DESCRIPTION
Add exclusion for bower_components folder, as it is quite common to use in front-end projects. I ran into an uncaught failure message after installing Bootstrap via Bower. I can't think of any issues including it in the exclusion list. Please consider including it.

Thanks.
~Jay
